### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary

Use `php` instead of `phpdbg` in the `coverage` Makefile target so this repository matches the org-wide migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps `messenger-skeleton` aligned with that change.

## Changes

- replace `-p phpdbg` with `-p php` in `Makefile`

## Testing

- [x] `make coverage` was attempted locally
- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification blocked locally because the current PHP setup has no Xdebug, PCOV, or PHPDBG coverage driver